### PR TITLE
Update deps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,16 +13,16 @@ edition = "2021"
 
 [dependencies.ethers]
 git = "https://github.com/gakonst/ethers-rs"
-version = "0.17.0"
+version = "1.0"
 
 [dependencies.serde_json]
-version = "1.0.85"
+version = "1.0"
 
 [dependencies.reqwest]
 version = "0.11.12"
 
 [dependencies.serde]
-version = "1.0.145"
+version = "1.0"
 
 [dependencies.chrono]
 version = "0.4"


### PR DESCRIPTION
It appears you overwrote my commit and ethers-rs is back to 0.17.0. This throws error on compilation for me.
This patch updates ethers-rs to version 1.0.x. It also removes patch version from stable crates (serde, serde_json).